### PR TITLE
Prompt for subtitle language in SoftMux

### DIFF
--- a/bot/start.py
+++ b/bot/start.py
@@ -802,6 +802,17 @@ async def _softmux_subtitles(event):
                             sub_dw_loc = check_file(f"{process_status.dir}/subtitles", sub_name)
                             sub_path = await new_event.download_media(file=sub_dw_loc)
                             process_status.append_subtitles(sub_path)
+                            sub_lang = await ask_text(chat_id, user_id, event, 120, f"Send Language For Subtitle No {file_index}", str)
+                            if sub_lang:
+                                if sub_lang == 'stop':
+                                    break
+                                elif sub_lang == 'cancel':
+                                    Cancel = True
+                                    break
+                                process_status.sub_langs.append(sub_lang)
+                            else:
+                                Cancel = True
+                                break
                             file_index+=1
                         else:
                             await event.reply("❌Subtitle Size Is More Than 500KB, Is This Really A Subtitle File")

--- a/bot/start.py
+++ b/bot/start.py
@@ -802,11 +802,12 @@ async def _softmux_subtitles(event):
                             sub_dw_loc = check_file(f"{process_status.dir}/subtitles", sub_name)
                             sub_path = await new_event.download_media(file=sub_dw_loc)
                             process_status.append_subtitles(sub_path)
-                            sub_lang = await ask_text(chat_id, user_id, event, 120, f"Send Language For Subtitle No {file_index}", str)
-                            if sub_lang:
-                                if sub_lang == 'stop':
+                            sub_lang_event = await ask_text_event(chat_id, user_id, event, 120, f"Send Language for File No {file_index}", message_hint=f"🔷Send `stop` To Process SoftMux\n🔷Send `cancel` To Cancel SoftMux Process")
+                            if sub_lang_event:
+                                sub_lang = str(sub_lang_event.message.message).strip()
+                                if sub_lang.lower() == 'stop':
                                     break
-                                elif sub_lang == 'cancel':
+                                elif sub_lang.lower() == 'cancel':
                                     Cancel = True
                                     break
                                 process_status.sub_langs.append(sub_lang)

--- a/bot_helper/FFMPEG/FFMPEG_Commands.py
+++ b/bot_helper/FFMPEG/FFMPEG_Commands.py
@@ -202,6 +202,8 @@ def get_commands(process_status):
                 command += ['-c','copy']
 
         command += ["-c:s", f"{get_data()[process_status.user_id]['softmux']['sub_codec']}"]
+        for i, lang in enumerate(process_status.sub_langs):
+            command += [f"-metadata:s:s:{i}", f"language={lang}"]
 # START OF MODIFIED BLOCK
         if apply_user_metadata_globally:
             LOGGER.info(f"SOFTMUX: Applying custom metadata. User text: '{user_global_metadata_text}'")

--- a/bot_helper/Process/Process_Status.py
+++ b/bot_helper/Process/Process_Status.py
@@ -310,6 +310,7 @@ class ProcessStatus:
                 self.send_files = []
                 self.dw_files = []
                 self.subtitles = []
+                self.sub_langs = []
                 self.dw_index = "-/-"
                 self.file_name = file_name
                 self.status_message_id = gen_random_string(5)


### PR DESCRIPTION
Implemented interactive language prompting for subtitles during the SoftMux (remux) process. After each subtitle file is uploaded, the bot asks for its language code. The user can also send 'stop' to start processing or 'cancel' to abort at this stage. These languages are then correctly applied as metadata to the respective subtitle tracks in the final video output. Other operations like MKS and HardMux remain unchanged.

---
*PR created automatically by Jules for task [4472334846204896783](https://jules.google.com/task/4472334846204896783) started by @IbrahimKhan2004*